### PR TITLE
Add BlackHat MEA 2025 Arsenal data

### DIFF
--- a/tools/MEA/2025/aI-augmented incident response.json
+++ b/tools/MEA/2025/aI-augmented incident response.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "AI-augmented incident response",
+  "Description": "Security teams drown in signals while attacks move across cloud infrastructure. This hands-onArsenal Lab turns that reality into a capture-the-flag challenge on a live AWS environmentrunning Amazon EKS. Participants will use an AI investigation agent - backed by Multiple MCP(Model Context Protocol) tool servers to triage Falco runtime detections, correlate Kubernetesaudit events, map AWS-side activity, and reconstruct the attack path. The CTF simulates arealistic intrusion (Ports scanning -> vulnerability/misconfiguration exploit -> lateral movement ->data exfil), and the agent guides each step by orchestrating queries against the tool stack,explaining reasoning, and generating next-best actions. The top 3 scorers win prizes.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Marat Salakhutdinov"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/angry_magpie.json
+++ b/tools/MEA/2025/angry_magpie.json
@@ -1,0 +1,14 @@
+{
+  "Tool Name": "Angry Magpie",
+  "Description": "Angry Magpie is a DLP bypass simulator demonstrating data splicing techniques that evade enterprise DLP solutions.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Venkata Pradyumna Cheerala",
+    "Shuvo Bardhan"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/apidetector.json
+++ b/tools/MEA/2025/apidetector.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "APIDetector",
+  "Description": "APIDetector v3 is an advanced, high-performance tool built for identifying and validating exposed Swagger/OpenAPI endpoints across domains and subdomains. Designed specifically for security professionals and developers, APIDetector v3 provides a modern web interface offering real-time results, interactive dashboards, automated screenshot captures, and intelligent false-positive detection.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Filipi Pires"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/black_bird.json
+++ b/tools/MEA/2025/black_bird.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Black Bird",
+  "Description": "Blackbird is an open-source OSINT tool for reverse account lookup by username and email across a wide range of online platforms. Integrated with the WhatsMyName project, it covers more than 600 sites and delivers verifiable evidence for digital investigations and online footprint mapping. Alongside its robust search and export features, Blackbird includes a *built-in AI analysis tool with a free daily quota*, allowing investigators to quickly interpret results and uncover patterns with zero extra setup.",
+  "GitHub URL": "https://github.com/p1ngul1n0/blackbird",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Filipi Pires"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/copycat.json
+++ b/tools/MEA/2025/copycat.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Copycat",
+  "Description": "Modern enterprises face escalating threats from sophisticated browser-based identity attacks that operate within legitimate authenticated sessions, bypassing traditional security controls like EDRs, SASE, and firewalls. This hands-on session equips blue team defenders with practical experience defending against ten real-world browser-based identity attack vectors using the open-source "Copycat" identity attack simulator extension.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Tejeswara Sunkugari"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/falconeye.json
+++ b/tools/MEA/2025/falconeye.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "FalconEye",
+  "Description": "FalconEye represents a new era in AI-driven security analysis, blending the power of locally hosted Large Language Models (LLMs) with advanced audit methodologies. Unlike traditional static analysis tools that rely on predefined patterns and generic scanning, FalconEye is designed to think and operate like an expert security auditor. At its core, FalconEye employs a system of intelligent AI agents that collaborate much like human audit teams—building dynamic knowledge graphs, forming hypotheses, and conducting targeted investigations. This approach allows it to not only identify vulnerabilities but also to understand their broader context within the system architecture.One of FalconEye’s defining strengths is its privacy-first design. Through seamless integration with Ollama, all analysis is conducted locally, ensuring sensitive codebases and data remain under the user’s control. The system also emphasizes performance optimization, leveraging task-specific models—ranging from lightweight quick scans to heavyweight reasoning models for deep analysis. Over time, FalconEye accumulates knowledge across sessions, enabling richer, more insightful analysis that evolves with the project.This session will provide a deep dive into FalconEye’s architecture and capabilities, showcasing how dynamic knowledge graphs, hypothesis-driven analysis, and multi-agent collaboration come together to deliver professional-grade security audits. Attendees will see firsthand how FalconEye transforms code reviews into a living, evolving process, and how it generates detailed, actionable security reports tailored for real-world use. Whether you are a security researcher, developer, or engineering leader, this session will demonstrate how FalconEye bridges the gap between automated tools and human expertise.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Rajanish Pathak"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/hardPwn.json
+++ b/tools/MEA/2025/hardPwn.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "HardPwn",
+  "Description": "HardPwn is a purpose-built hardware exploitation platform crafted for intermediate and advanced hardware hackers who want to push embedded devices, PCBs, and IoT gadgets to their limits. The toolkit elevates low-level hardware reconnaissance by automatically probing SPI, UART, I2C, and JTAG interfaces, performing chip-level reconnaissance where possible, executing NAND glitching on non-BGA chips, and dumping firmware—all with minimal setup. By automating over 90% of typical test cases, HardPwn transforms what traditionally takes months of manual exploration into a matter of hours.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Jinto Antony"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/ipti.json
+++ b/tools/MEA/2025/ipti.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "IPTI",
+  "Description": "Every device connected to the internet is inherently tied to an IP address— a unique numerical identifier assigned to each device within a computer network. In real-world scenarios, especially during product development, integration with third-party services often requires IP whitelisting to allow access to internal systems. However, this practice introduces security risks, making it imperative for security engineers to audit and validate the IP address reputation beforehand.While several trusted threat intelligence platforms such as VirusTotal, AbuseIPDB, AlienVault, and ThreatBook provide IP reputation services, relying on a single source is often insufficient due to inconsistent or outdated data. To overcome these limitations, IPTI – IP Threat Intelligence Tool was developed. IPTI aggregates reputation data from multiple reputable sources and enriches the analysis with additional context such as open port detection, server metadata, privacy indicators, and PTR record evaluation. These insights are then synthesized into a comprehensive risk-based scoring system, providing a more accurate and actionable assessment. IPTI is designed to be a practical and customizable tool to support security engineers in network access control and threat validation.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Bayu Fedra Abdullah"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/kanvas.json
+++ b/tools/MEA/2025/kanvas.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Kanvas",
+  "Description": "Kanvas is an open-source tool for incident response and forensics, enabling structured investigation workflows.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Jinto Antony"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/logsquash.json
+++ b/tools/MEA/2025/logsquash.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "LogSquash",
+  "Description": "LogSquash condenses and consolidates logs before SIEM ingestion to significantly reduce costs while retaining security value.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "ezzeldin tahoun"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/meetc2.json
+++ b/tools/MEA/2025/meetc2.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "MeetC2",
+  "Description": "A serverless command & control (C2) framework that leverages Google Calendar APIs, as a covert communication channel between operators and a compromised system.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Dhiraj Mishra"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/noizr.json
+++ b/tools/MEA/2025/noizr.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Noizr",
+  "Description":  "Today, security teams are overwhelmed by noisy alerts, false positives, and fragmented event streams often lacking clear, actionable insights. Responding effectively to real threats becomes increasingly complex in such environments.To address these challenges, we present a concept of the Universal SOC AI Plugin that integrates seamlessly with runtime threat detection tools. This solution tackles key pain points by:- Reducing noise and filtering out false positives- Prioritizing threats based on severity and context- Aggregating events to present a unified threat picture- Providing a flexible API interface for tailored integrations- Enabling webhooks for streamlined response via external systemsThis demo will showcase how the plugin enhances situational awareness, simplifies threat triage, and enables faster, more informed response actions across any SOC environment. As a team, we would love to hear your thoughts and feedback and collaborate further.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Marat Salakhutdinov"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/penelope_shell_handler.json
+++ b/tools/MEA/2025/penelope_shell_handler.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Penelope Shell Handler",
+  "Description": "Penelope is a shell handler designed to be easy to use and intended to replace netcat when exploiting RCE vulnerabilities. It is compatible with Linux and macOS and requires Python 3.6 or higher. It is a standalone script that does not require any installation or external dependencies, and it is intended to remain this way.",
+  "GitHub URL": "https://github.com/brightio/penelope",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Christodoulos Lamprinos"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/quantumlint.json
+++ b/tools/MEA/2025/quantumlint.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "QuantumLint",
+  "Description": "QuantumLint is an open source enhancement toolkit that extends existing Java static analysis utilities to assess quantum-vulnerability exposure in source code. It focuses on identifying the use of classical cryptographic algorithms such as RSA, ECC, and ECDH within Java projects. By leveraging standard parsing libraries, QuantumLint highlights code regions where quantum susceptible cryptography is referenced and categorizes findings by severity to inform migration planning.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Prasanth Sundararajan"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/saist.json
+++ b/tools/MEA/2025/saist.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "SAIST",
+  "Description": "SAIST (Static AI-powered Scanning Tool) is an open-source project that scans codebases for vulnerabilities using AI.It supports multiple LLMs, and can scan full codebases, diffs between commits, or even GitHub PRs automatically.The common use cases are:- Scan an entire application's code base with your favourite LLM (OpenAI, Deepseek etc) and get a PDF report- Scan a code change and comment on a pull requestSAIST allows you to control which LLM is used, such as AWS bedrock or Azure OpenAI. This provides you with greater control of your own data sovereignty, whilst giving you industry-leading capabilities.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Simon Gurney"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/sense_ai.json
+++ b/tools/MEA/2025/sense_ai.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Sense-AI",
+  "Description": "SENSE (Shadow Exposure & eNterprise Surveillance for AI) is an open-source cybersecurity tool designed to detect and monitor unauthorized or "shadow" AI instances in enterprise environments. As organizations increasingly adopt AI technologies, unapproved AI services—such as external API calls to platforms like OpenAI or Hugging Face, or local model execution—pose significant security and compliance risks. SENSE addresses this emerging threat by analyzing network traffic and endpoint processes to identify AI-related activities, providing enterprises with critical visibility into shadow AI usage.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Sanket Sarkar"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/skyeye.json
+++ b/tools/MEA/2025/skyeye.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "SkyEye",
+  "Description":"In this Arsenal session, we will showcase a new framework: SkyEye - The First Cooperative Multi-Principal IAM Enumeration Framework for AWS CloudSkyEye Framework proposed and developed two novel models: CPIEM and TCREM. Unlike conventional tools and frameworks, SkyEye is able to synchronize reconnaissance across multiple user and role sessions, dynamically chaining and merging their vantage points to unravel the full spectrum of permissions, resource authorizations, and hidden escalation paths. This methodology exposes not only what each principal can see, but also what they can achieve in combination, uncovering hidden attack vectors and privilege escalation paths invisible to traditional IAM enumeration.",
+  "GitHub URL": "https://github.com/0x7a6b4c/SkyEye",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Minh Hoang Nguyen"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/smithy_the_appsec_soar.json
+++ b/tools/MEA/2025/smithy_the_appsec_soar.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "Smithy the AppSec SOAR",
+  "Description": "Smithy is an open-source framework designed to supercharge your AppSec automation using AI-driven orchestration. In this Arsenal session, we’ll showcase how Smithy helps security teams build and scale intelligent workflows that unify tools, triage results, and automate actions—all without writing brittle glue code.",
+  "GitHub URL": "https://github.com/smithy-security/smithy",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Spyros Gasteratos"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}

--- a/tools/MEA/2025/vsxploit.json
+++ b/tools/MEA/2025/vsxploit.json
@@ -1,0 +1,13 @@
+{
+  "Tool Name": "VSXPLOIT",
+  "Description": "VSXPloit is a framework for weaponizing VS Code Remote Dev Tunnels, automating tunnel exploitation, payload generation, and covert exfiltration via GitHub.",
+  "GitHub URL": "",
+  "Tracks": [
+    "Arsenal"
+  ],
+  "Speakers": [
+    "Suman Kumar Chakraborty"
+  ],
+  "Region": "MEA",
+  "Year": "2025"
+}


### PR DESCRIPTION
This pull request adds the complete Black Hat MEA 2025 Arsenal dataset.

- Added a new folder: tools/MEA/2025
- Included all Arsenal tools presented at Black Hat MEA 2025
- Each tool is stored as an individual JSON file
- Data includes tool name, description, speakers, track, region, year, and GitHub links where available

This keeps the repository up to date with the latest MEA Arsenal content and follows the existing folder structure.